### PR TITLE
Consistency with the output on the web side of things

### DIFF
--- a/app/Console/Commands/OutputStats.php
+++ b/app/Console/Commands/OutputStats.php
@@ -21,7 +21,7 @@ class OutputStats extends Command
                 return $project->debtScore();
             })->map(function ($project) {
                 return [
-                    $project->name,
+                    sprintf('%s/%s', $project->namespace, $project->name),
                     $this->formatDebtScore($project->debtScore()),
                 ];
             })


### PR DESCRIPTION
Came across Ozzie today and thought it might be useful, so started to play around with it locally.  I noticed that the console output of the projects didn't include namespace, which might be helpful if you had multiple namespaces used (though I appreciate it was intended for the tighten namespace), and gives it a consistent project name output as the web side of things.

Thanks for your consideration!