### PR TITLE
Normalise cache table

### DIFF
--- a/app/Snapshot.php
+++ b/app/Snapshot.php
@@ -10,7 +10,7 @@ class Snapshot extends Model
 
     public function scopeToday($query)
     {
-        return $query->whereDate('created_at', '=', now()->format('Y-m-d'));
+        return $query->whereDate('snapshot_date', '=', now()->format('Y-m-d'));
     }
 
     public function project()

--- a/app/Snapshot.php
+++ b/app/Snapshot.php
@@ -12,4 +12,9 @@ class Snapshot extends Model
     {
         return $query->whereDate('created_at', '=', now()->format('Y-m-d'));
     }
+
+    public function project()
+    {
+        return $this->belongsTo('App\SnapshotProject');
+    }
 }

--- a/app/SnapshotProject.php
+++ b/app/SnapshotProject.php
@@ -8,6 +8,7 @@ class SnapshotProject extends Model
 {
     protected $guarded = [];
     protected $table = 'projects';
+    public $timestamps = false;
 
     public function snapshots()
     {

--- a/app/SnapshotProject.php
+++ b/app/SnapshotProject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SnapshotProject extends Model
+{
+    protected $guarded = [];
+    protected $table = 'projects';
+
+    public function snapshots()
+    {
+        return $this->hasMany('App\Snapshot');
+    }
+}

--- a/database/migrations/2020_09_25_221257_normalise_snapshots_table.php
+++ b/database/migrations/2020_09_25_221257_normalise_snapshots_table.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Projects;
+use App\Snapshot;
+use App\SnapshotProject;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class NormaliseSnapshotsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('namespace');
+            $table->string('name');
+        });
+
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->foreignId('project_id')->after('name');
+        });
+
+        $projects = (new Projects)->load();
+        if (!$projects->isEmpty()) {
+            $data = $projects->map(function ($project) {
+                return [
+                    'namespace' => $project->namespace,
+                    'name' => $project->name
+                ];
+            });
+            DB::table('projects')->insert($data->toArray());
+            SnapshotProject::all(['id', 'name'])->each(function($project) {
+                Snapshot::where('name', '=', $project->name)->update([
+                    'project_id' => $project->id
+                ]);
+            });
+        }
+
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->string('name')->after('id');
+        });
+
+        SnapshotProject::all(['id', 'name'])->each(function($project) {
+            Snapshot::where('project_id', '=', $project->id)->update([
+                'name' => $project->name
+            ]);
+        });
+
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->dropColumn('project_id');
+        });
+
+        Schema::dropIfExists('projects');
+    }
+}


### PR DESCRIPTION
The snapshots update is great, but I've made some updates for your consideration...

When you've done lots of snapshots, you'll eventually end up with a lot of duplicated string.  So I've normalised that a bit with an additional table.  The things that have changed are:

* Added migration that will add new table and convert any existing data
* Added new model for the snapshots projects table
* Added relationships in the two models
* Create snapshot projects on-the-fly as required
* Used namespace as well to be more specific

Also, I believe there was a bug in the checking of dates; the command used the 'snapshot_date' to filter but the Snapshot 'today' scope used 'created_at' which meant they could get offset and not insert or update as needed.  So these were made consistent using the 'snapshot_date' value for both.

Thanks!