### PR TITLE
grab and store composer downloads

### DIFF
--- a/app/Console/Commands/CreateProjectSnapshots.php
+++ b/app/Console/Commands/CreateProjectSnapshots.php
@@ -44,6 +44,8 @@ class CreateProjectSnapshots extends Command
                     'old_issue_count' => $project->oldIssues()->count(),
                     'pull_request_count' => $project->prs()->count(),
                     'old_pull_request_count' => $project->oldPrs()->count(),
+										'download_totals' => $project->downloadsTotal(),
+										'download_last_30_days' => $project->downloadsMonthly(),
                 ]
             );
         });

--- a/database/migrations/2020_10_05_225325_add_downloads_to_snapshot_table.php
+++ b/database/migrations/2020_10_05_225325_add_downloads_to_snapshot_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDownloadsToSnapshotTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+						$table->integer('download_totals')->default(0)->after('old_issue_count');
+						$table->integer('download_last_30_days')->default(0)->after('download_totals');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->dropColumn(['download_totals', 'download_last_30_days']);
+        });
+    }
+}

--- a/resources/views/components/debt-table.blade.php
+++ b/resources/views/components/debt-table.blade.php
@@ -24,7 +24,11 @@
 
             <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Prs</th>
 
-            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Issues</th>
+						<th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Issues</th>
+
+						<th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Total Downloads</th>
+
+            <th class="text-grey-darkest font-bold uppercase text-xs leading-none tracking-wide p-4">Monthly Downloads</th>
 
             @if ($hacktoberfest)
                 <th class="text-xs p-4">🎃</th>
@@ -50,7 +54,11 @@
 
                 <td class="text-black-lightest p-4">{{ $project->prs()->count() }}</td>
 
-                <td class="text-black-lightest p-4">{{ $project->issues()->count() }}</td>
+								<td class="text-black-lightest p-4">{{ $project->issues()->count() }}</td>
+
+								<td class="text-black-lightest p-4">{{ $project->packagistDownloads('total') }}</td>
+
+                <td class="text-black-lightest p-4">{{ $project->packagistDownloads('monthly') }}</td>
 
                 @if ($hacktoberfest)
                     <td class="p-4">


### PR DESCRIPTION
Migrated the snapshot table to store downloads, both totalt and monthly. The grab from packagist.org is setup to run on the daily snapshot.

The sparklines are missing, though.
#35 