### PR TITLE
Configurably show projects on their own page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://ozzie.test
 APP_ORG="Tighten"
+PAGINATE_PROJECTS=false
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -14,6 +14,7 @@ class DashboardController extends Controller
         return view('dashboard', [
             'projects' => (new Projects)->all(),
             'hacktoberfest' => $hacktoberfest,
+            'paginated' => config('app.paginate_projects'),
         ]);
     }
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Projects;
+
+class ProjectController extends Controller
+{
+    public function show(string $namespace, string $name)
+    {
+        $project = (new Projects)->find($namespace, $name);
+
+        return view('projects.show', [
+            'project' => $project,
+        ]);
+    }
+}

--- a/app/Project.php
+++ b/app/Project.php
@@ -90,6 +90,18 @@ class Project
         return 'https://github.com/' . $this->namespace . '/' . $this->name;
     }
 
+    public function link()
+    {
+        if (config('app.paginate_projects')) {
+            return route('projects.show', [
+                'namespace' => $this->namespace,
+                'name' => $this->name,
+            ]);
+        }
+
+        return "#project-{$this->namespace}-{$this->name}";
+    }
+
     protected function hydrateIssues()
     {
         $this->issues = $this->github->projectIssues($this->namespace, $this->name);

--- a/app/Projects.php
+++ b/app/Projects.php
@@ -20,6 +20,23 @@ class Projects
         });
     }
 
+    public function find(string $namespace, string $name)
+    {
+        return Cache::remember("{$namespace}.{$name}", 60 * 60, function () use ($namespace, $name) {
+            return $this->load()
+                ->where('namespace', $namespace)
+                ->where('name', $name)
+                ->map(function ($project) {
+                    return new Project(
+                        $project->namespace,
+                        $project->name,
+                        $project->maintainers
+                    );
+                })
+                ->first();
+        });
+    }
+
     public function load()
     {
         return collect(

--- a/config/app.php
+++ b/config/app.php
@@ -28,6 +28,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Show projects on a separate page
+    |--------------------------------------------------------------------------
+    |
+    | Show all project repositories on a single page or each on a separate page.
+    | If the value is set to false, all projects are shown on a single page.
+    | If the value is set to true, each project will have a separate page.
+    |
+    */
+
+    'paginate_projects' => env('PAGINATE_PROJECTS', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Environment
     |--------------------------------------------------------------------------
     |

--- a/resources/views/components/debt-table.blade.php
+++ b/resources/views/components/debt-table.blade.php
@@ -37,7 +37,7 @@
             <tr class="border-t border-smoke">
                 <td class="p-4">
                     <a class="text-indigo no-underline text-md p-2 -mx-2"
-                       href="#project-{{ $project->namespace }}-{{ $project->name }}">
+                       href="{{ $project->link() }}">
                         {{ $project->namespace }}/{{ $project->name }}
                     </a>
                 </td>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <meta name="description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
+
+    <meta property="og:site_name" content="Ozzie">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:title" content="Ozzie">
+    <meta property="og:url" content="https://ozzie.tighten.co/">
+    <meta property="og:type" content="website">
+    <meta property="og:description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
+
+    <meta property="og:image" content="https://ozzie.tighten.co/ozzie-opengraph.png">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:width" content="1200">
+
+    <meta name="twitter:site" content="@tightenco">
+    <meta name="twitter:creator" content="@tightenco">
+    <meta name="twitter:title" content="Ozzie">
+    <meta name="twitter:description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="https://ozzie.tighten.co/ozzie-opengraph.png">
+
+    <link rel="stylesheet" type="text/css" href="{{ asset('css/main.css') }}">
+
+    <title>Ozzie - {{ config('app.organization') }}</title>
+</head>
+
+<body>
+<div class="bg-white border-t-4 border-indigo relative z-10 shadow">
+    <section class="max-w-4xl mx-auto px-2">
+        <div class="flex justify-between items-center">
+            <h1 class="flex items-center">
+                <span class="font-light text-5xl text-indigo">O</span>
+
+                <span class="uppercase text-2xl leading-normal text-black-light font-semibold font-sans tracking-wide">zzie</span>
+            </h1>
+
+            <p class="font-sans italic font-normal leading-normal tracking-tight text-grey-blue-darkest">Addressing our open source debt</p>
+        </div>
+    </section>
+</div>
+
+<div id="app" class="bg-frost font-sans relative overflow-x-auto z-0">
+    <div class="max-w-4xl mx-auto px-2 py-6">
+        {{ $slot }}
+    </div>
+</div>
+<script src="{{ asset('js/app.js') }}" defer></script>
+</body>
+</html>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,60 +1,9 @@
-<!doctype html>
-<html lang="{{ app()->getLocale() }}">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+<x-layout>
+    <x-debt-table :projects="$projects" :hacktoberfest="$hacktoberfest"/>
 
-        <meta name="description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
-
-        <meta property="og:site_name" content="Ozzie">
-        <meta property="og:locale" content="en_US">
-        <meta property="og:title" content="Ozzie">
-        <meta property="og:url" content="https://ozzie.tighten.co/">
-        <meta property="og:type" content="website">
-        <meta property="og:description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
-
-        <meta property="og:image" content="https://ozzie.tighten.co/ozzie-opengraph.png">
-        <meta property="og:image:height" content="630">
-        <meta property="og:image:width" content="1200">
-
-        <meta name="twitter:site" content="@tightenco">
-        <meta name="twitter:creator" content="@tightenco">
-        <meta name="twitter:title" content="Ozzie">
-        <meta name="twitter:description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
-
-        <meta name="twitter:card" content="summary_large_image">
-        <meta name="twitter:image" content="https://ozzie.tighten.co/ozzie-opengraph.png">
-
-        <link rel="stylesheet" type="text/css" href="css/main.css">
-
-        <title>Ozzie - {{ config('app.organization') }}</title>
-    </head>
-
-    <body>
-        <div class="bg-white border-t-4 border-indigo relative z-10 shadow">
-            <section class="max-w-4xl mx-auto px-2">
-                <div class="flex justify-between items-center">
-                    <h1 class="flex items-center">
-                        <span class="font-light text-5xl text-indigo">O</span>
-
-                        <span class="uppercase text-2xl leading-normal text-black-light font-semibold font-sans tracking-wide">zzie</span>
-                    </h1>
-
-                    <p class="font-sans italic font-normal leading-normal tracking-tight text-grey-blue-darkest">Addressing our open source debt</p>
-                </div>
-            </section>
-        </div>
-
-        <div id="app" class="bg-frost font-sans relative overflow-x-auto z-0">
-            <div class="max-w-4xl mx-auto px-2 py-6">
-                <x-debt-table :projects="$projects" :hacktoberfest="$hacktoberfest"/>
-
-                @foreach ($projects as $project)
-                    <x-project :project="$project" />
-                @endforeach
-            </div>
-        </div>
-        <script src="{{ asset('js/app.js') }}" defer></script>
-    </body>
-</html>
+    @unless ($paginated)
+        @foreach ($projects as $project)
+            <x-project :project="$project" />
+        @endforeach
+    @endunless
+</x-layout>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -1,0 +1,5 @@
+<x-layout>
+    <a href="/"> &larr; All projects</a>
+
+    <x-project :project="$project" />
+</x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,3 +1,4 @@
 <?php
 
-Route::get('/', 'DashboardController@show');
+Route::get('/', 'DashboardController@show')->name('dashboard');
+Route::get('/projects/{namespace}/{name}', 'ProjectController@show')->name('projects.show');


### PR DESCRIPTION
## Intro
This PR adds the functionality as proposed in #65, where you are now able to specify wether or not to split repositories into their own page by specifying a `PAGINATE_PROJECTS` environment variable.

@mattstauffer is the kind of implementation you were thinking of?

## What has been done
- Added a `paginate_projects` key in `config/app.php`
- Added a route, controller and view to show a single project
- Extracted shared HTML to a `layout` partial component
- Added a `find()` method to the `Projects` repository class which can return a single `Project` given a `$name` and `$namespace`
- Extracted the hard coded link to a project in the "debt table" to a method `link()` on the `Project` class, which either provides an anchor tag (when pagination disabled) or a link to the `project.show` route (when pagination enabled).
- Refactor to use `{{ asset('css/main.css') }}` instead of a hard coded link to the `main.css` file

## How to test
- In the `.env` file, update the `PAGINATE_PROJECTS` variable to `false`
- Assert that all links are anchor tags, referencing the projects which are listed below the "debt table"
- In the `.env` file, update the `PAGINATE_PROJECTS` variable to `true`
- Assert that the links to the projects are now pointing to `/projects/{namespace}/{name}` and each project has their own separate page

(closes #65)