### PR TITLE
Update the uses of APP_NAME and APP_ORG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://ozzie.test
-APP_ORG="Tighten"
+APP_ORG=tighten
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
-APP_NAME="Ozzie"
+APP_NAME="Tighten"
+# Your organization's GitHub name
+APP_ORG=tighten
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://ozzie.test
-APP_ORG=tighten
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1

--- a/config/app.php
+++ b/config/app.php
@@ -4,10 +4,10 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Organization/Company Name
+    | Organization/Company GitHub Name
     |--------------------------------------------------------------------------
     |
-    | In our case, it's "Tighten". In your case it could be anything.
+    | In our case, it's "tighten". In your case it could be anything.
     |
     */
 
@@ -24,7 +24,7 @@ return [
     |
     */
 
-    'name' => env('APP_NAME', 'Ozzie'),
+    'name' => env('APP_NAME', 'Tighten'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -11,7 +11,7 @@ return [
     |
     */
 
-    'organization' => env('APP_ORG', 'Tighten'),
+    'organization' => env('APP_ORG', 'tighten'),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/components/debt-table.blade.php
+++ b/resources/views/components/debt-table.blade.php
@@ -2,7 +2,7 @@
     <p class="mb-6 text-black-lighter">Projects in descending order of "debt" (how much attention it needs)</p>
 
     @if ($hacktoberfest)
-        <a href="https://github.com/search?o=desc&q=label%3Ahacktoberfest+is%3Aopen+type%3Aissue+user%3Atighten&s=created&type=Issues"
+        <a href="https://github.com/search?o=desc&q=label%3Ahacktoberfest+is%3Aopen+type%3Aissue+user%3A{{ config('app.organization') }}&s=created&type=Issues"
            target="_blank" rel="noopener noreferrer"
            class="mb-6 px-4 py-3 bg-grey-blue hover:bg-halloween-orange no-underline rounded-lg text-black-lighter hover:text-white hover-pop">
             Hacktoberfest is here! 👻

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -5,14 +5,14 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <meta name="description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
+        <meta name="description" content="Ozzie - {{ config('app.name') }}'s Open Source Project Dashboard">
 
         <meta property="og:site_name" content="Ozzie">
         <meta property="og:locale" content="en_US">
         <meta property="og:title" content="Ozzie">
         <meta property="og:url" content="https://ozzie.tighten.co/">
         <meta property="og:type" content="website">
-        <meta property="og:description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
+        <meta property="og:description" content="Ozzie - {{ config('app.name') }}'s Open Source Project Dashboard">
 
         <meta property="og:image" content="https://ozzie.tighten.co/ozzie-opengraph.png">
         <meta property="og:image:height" content="630">
@@ -21,7 +21,7 @@
         <meta name="twitter:site" content="@tightenco">
         <meta name="twitter:creator" content="@tightenco">
         <meta name="twitter:title" content="Ozzie">
-        <meta name="twitter:description" content="Ozzie - {{ config('app.organization') }}'s Open Source Project Dashboard">
+        <meta name="twitter:description" content="Ozzie - {{ config('app.name') }}'s Open Source Project Dashboard">
 
         <meta name="twitter:card" content="summary_large_image">
         <meta name="twitter:image" content="https://ozzie.tighten.co/ozzie-opengraph.png">
@@ -29,7 +29,7 @@
         <link rel="stylesheet" type="text/css" href="css/main.css">
         <link rel="stylesheet" type="text/css" href="css/vendor.css">
 
-        <title>Ozzie - {{ config('app.organization') }}</title>
+        <title>Ozzie - {{ config('app.name') }}</title>
     </head>
 
     <body>


### PR DESCRIPTION
This pull request implements the change I suggested in #69.

Instead of `APP_ORG` being displayed in the title of the page, it is used as the name of the Github organisation. It also no longer hard codes the `tighten` Github username into the `Hacktoberfest is here!` URL for searching issues.

Let me know if you have any questions or if I missed anything.