### PR TITLE
Fix failing composer installations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer install --prefer-dist --no-interaction --no-progress
+              run: composer update --prefer-dist --no-interaction --no-progress
 
             - name: Run Tlint
               run: vendor/bin/tlint

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,7 @@ jobs:
           coverage: none
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-interaction --no-progress
+      run: composer update --prefer-dist --no-interaction --no-progress
 
     - name: Run PHP tests
       run: vendor/bin/phpunit


### PR DESCRIPTION
The `run-test.yml` workflow is failing due to unsatisfiable composer package dependencies. Specifically, package versions in `composer-lock.json` that are incompatible with the PHP version of the currently running container. 

Running `composer update` instead of `composer install` during a fresh installation first upgrades/downgrades  any packages as appropriate before automatically executing a `composer install`.

**Alternative Options**
We could remove `package-lock.json` from version control.

fixes #102 (failing workflows)