### PR TITLE
Use an empty string instead of null when a Github Issue has no body text.

### DIFF
--- a/app/Cache/CachedIssue.php
+++ b/app/Cache/CachedIssue.php
@@ -19,7 +19,7 @@ class CachedIssue
                 return [
                     'project' => $project->jsonSerialize(),
                     'issue' => $project->$type($id),
-                    'body' => app(ParseMarkdown::class)($project->$type($id)['body']),
+                    'body' => app(ParseMarkdown::class)($project->$type($id)['body'] ? $project->$type($id)['body'] : ''),
                 ];
             }
         );


### PR DESCRIPTION
This pull request updates `CachedIssue.php` to check for `null` body text.  If it is null, `'body'` is set to an empty string. 
This resolves [an error](https://app.bugsnag.com/tighten/ozzie/errors/617576fd26699e000797bc19?event_id=617576fd0087120d51b10000&i=em&m=nw) in production that occurs when a user clicks a Github Issue that has no description text.
 
Before change:
<img width="800" alt="Screen Shot 2021-10-26 at 12 19 43 PM" src="https://user-images.githubusercontent.com/85198527/138929056-be2e47e8-5ff0-4393-984d-e818a5d7a6c1.png">

After change:
<img width="800" alt="Screen Shot 2021-10-26 at 12 14 29 PM" src="https://user-images.githubusercontent.com/85198527/138928843-0928e727-49d8-4d38-8a34-6241c4a74783.png">
