### PR TITLE
Improve seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can see you'll define the GitHub namespace, the GitHub project name, and the
 The list of projects resides in `projects.json`, and is seeded to the `projects` table using `database/seeds/ProjectsSeeder.php`. This means that any changes to projects needs to happen in `projects.json` _first_. Migrating and seeding tables fresh will update the `projects` table with the new info, and the next call of `php artisan stats:fetch` will re-populate project stats.
 
 1. Make a change to `projects.json`
-2. Drop and re-migrate all tables: `php artisan migrate:fresh --seed`
+2. Re-run the seeder: `php artisan db:seed`
 3. Fetch all project stats: `php artisan stats:fetch`
 
 ### Daily Caching

--- a/database/seeds/ProjectsSeeder.php
+++ b/database/seeds/ProjectsSeeder.php
@@ -16,16 +16,22 @@ class ProjectsSeeder extends Seeder
 
         collect(json_decode($projectsJson, true))
             ->each(function ($project) {
-                Project::create([
+                $project = Project::updateOrCreate([
                     'namespace' => $project['namespace'],
                     'name' => $project['name'],
+                ], [
                     'packagist_name' => $project['packagist_name'] ?? null,
-                    'maintainers' => $project['maintainers'],
-                    'issues_count' => 0,
-                    'pull_requests_count' => 0,
-                    'issues' => [],
-                    'pull_requests' => [],
+                    'maintainers' => $project['maintainers'] ?? [],
                 ]);
+
+                if ($project->wasRecentlyCreated) {
+                    $project->update([
+                        'issues_count' => 0,
+                        'pull_requests_count' => 0,
+                        'issues' => [],
+                        'pull_requests' => [],
+                    ]);
+                }
             });
     }
 }


### PR DESCRIPTION
Make it possible to re-run the seeder when you change the `projects.json` file.

This comes in handy when you don't want to lose the snapshots of the pre-existing projects that you are already tracking.

I tried to keep the change as small as possible to make reviewing a lot easier ;)