### PR TITLE
Add `is_hidden` Attribute To Project Resource

### DIFF
--- a/app/Http/Resources/Api/ProjectResource.php
+++ b/app/Http/Resources/Api/ProjectResource.php
@@ -20,6 +20,7 @@ class ProjectResource extends JsonResource
                 'name',
                 'packagist_name',
                 'maintainers',
+                'is_hidden',
                 'issues',
                 'pull_requests',
                 'downloads_total',


### PR DESCRIPTION
# Summary
Sauce relies on Ozzie for syncing with and displaying information about internal projects (20% projects). We need the `is_hidden` key available so we can display active only internal projects.