### PR TITLE
Remove `gistlog.co` and `novapackages.com`

### DIFF
--- a/projects.json.dist
+++ b/projects.json.dist
@@ -17,14 +17,6 @@
         ]
     },
     {
-        "name": "gistlog",
-        "namespace": "tighten",
-        "packagist_name": "tightenco/gistlog",
-        "maintainers": [
-            "mattstauffer"
-        ]
-    },
-    {
         "name": "jigsaw",
         "namespace": "tighten",
         "packagist_name": "tightenco/jigsaw",
@@ -83,15 +75,6 @@
         "namespace": "tighten",
         "packagist_name": "tightenco/mailthief",
         "maintainers": []
-    },
-    {
-        "name": "novapackages",
-        "namespace": "tighten",
-        "packagist_name": "tightenco/novapackages",
-        "maintainers": [
-            "marcusmoore",
-            "darkboywonder"
-        ]
     },
     {
         "name": "nova-google-analytics",


### PR DESCRIPTION
This PR removes `gistlog.co` and `novapackages.com`.