### PR TITLE
Make `is_hidden` sticky

### DIFF
--- a/app/Cache/CachedProjectList.php
+++ b/app/Cache/CachedProjectList.php
@@ -15,7 +15,6 @@ class CachedProjectList
             function () {
                 return [
                     'projects' => Project::all()
-                        ->filter(fn ($project) => ! $project->is_hidden)
                         ->transform(fn ($project) => app(CachedProjectResource::class)($project->packagist_name))
                         ->sortByDesc(fn ($project) => $project['debt_score'])
                         ->values(),

--- a/app/Cache/CachedProjectList.php
+++ b/app/Cache/CachedProjectList.php
@@ -14,7 +14,7 @@ class CachedProjectList
             'projects',
             function () {
                 return [
-                    'projects' => Project::all()
+                    'projects' => Project::visible()->get()
                         ->transform(fn ($project) => app(CachedProjectResource::class)($project->packagist_name))
                         ->sortByDesc(fn ($project) => $project['debt_score'])
                         ->values(),

--- a/app/Console/Commands/FetchProjectStats.php
+++ b/app/Console/Commands/FetchProjectStats.php
@@ -16,7 +16,7 @@ class FetchProjectStats extends Command
 
     public function handle()
     {
-        $projects = Project::withOutGlobalScope('hidden')->get();
+        $projects = Project::all();
 
         $this->createProgressBar($projects->count());
 

--- a/app/Console/Commands/FetchProjectStats.php
+++ b/app/Console/Commands/FetchProjectStats.php
@@ -16,7 +16,7 @@ class FetchProjectStats extends Command
 
     public function handle()
     {
-        $projects = Project::all();
+        $projects = Project::withOutGlobalScope('hidden')->get();
 
         $this->createProgressBar($projects->count());
 
@@ -53,7 +53,7 @@ class FetchProjectStats extends Command
         $project->downloads_total = $packagist->totalDownloads;
         $project->downloads_last_30_days = $packagist->monthlyDownloads;
 
-        $project->is_hidden = $githubProject->isArchived();
+        $project->is_hidden = $githubProject->isArchived() || $project->is_hidden;
 
         $project->save();
     }

--- a/app/Notifications/SendOzzieStats.php
+++ b/app/Notifications/SendOzzieStats.php
@@ -37,7 +37,7 @@ class SendOzzieStats extends Notification
                     ]);
             });
 
-        Project::all()
+        Project::visible()->get()
             ->filter(fn ($project) => $project->debtScore() > 0)
             ->sortByDesc(function ($project) {
                 return $project->debtScore();

--- a/app/Notifications/SendOzzieStats.php
+++ b/app/Notifications/SendOzzieStats.php
@@ -38,7 +38,6 @@ class SendOzzieStats extends Notification
             });
 
         Project::all()
-            ->filter(fn ($project) => ! $project->is_hidden)
             ->filter(fn ($project) => $project->debtScore() > 0)
             ->sortByDesc(function ($project) {
                 return $project->debtScore();

--- a/app/Project.php
+++ b/app/Project.php
@@ -26,13 +26,6 @@ class Project extends Model
         'pull_requests' => 'collection',
     ];
 
-    protected static function booted(): void
-    {
-        static::addGlobalScope('hidden', function (Builder $builder) {
-            $builder->where('is_hidden', false);
-        });
-    }
-
     public function snapshots()
     {
         return $this->hasMany(Snapshot::class);
@@ -41,6 +34,11 @@ class Project extends Model
     public function snapshotToday()
     {
         return $this->hasMany(Snapshot::class)->today();
+    }
+
+    public function scopeVisible(Builder $query): Builder
+    {
+        return $query->where('is_hidden', false);
     }
 
     public function scopeFromVendorAndName(Builder $query, string $projectNamespace, string $projectName): Builder

--- a/app/Project.php
+++ b/app/Project.php
@@ -26,6 +26,13 @@ class Project extends Model
         'pull_requests' => 'collection',
     ];
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope('hidden', function (Builder $builder) {
+            $builder->where('is_hidden', false);
+        });
+    }
+
     public function snapshots()
     {
         return $this->hasMany(Snapshot::class);


### PR DESCRIPTION
This PR makes `is_hidden` default to the current database value.

The daily `projects:fetch` command syncs projects from the GitHub organization.  Without this change, the only way to hide projects is to archive them in GitHub.  Making `is_hidden` default to the current database value allows us to mark projects as hidden in the database regardless of them being archived in GitHub. 

These hidden projects will continue to be updated in case they become visible.

