### PR TITLE
Laravel 10 Mid-Shift

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -61,6 +61,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
+        'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
         "guzzlehttp/guzzle": "^7.2",
         "http-interop/http-factory-guzzle": "^1.2",
         "inertiajs/inertia-laravel": "^0.6.9",
-        "laravel/framework": "^10.15",
+        "laravel/framework": "^10.23",
         "laravel/tinker": "^2.8",
         "nathanheffley/laravel-slack-blocks": "^2.3",
-        "laravel/nova": "~4.0",
-        "laravel/socialite": "^5.6",
+        "laravel/nova": "^4.27",
+        "laravel/socialite": "^5.9",
         "laravel/ui": "^4.2",
         "spatie/data-transfer-object": "^3.9",
         "tightenco/ziggy": "^1.6"
@@ -40,9 +40,9 @@
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
         "phpunit/phpunit": "^10.1",
-        "spatie/laravel-ignition": "^2.0",
-        "spatie/laravel-ray": "^1.32",
-        "tightenco/duster": "^2.0"
+        "spatie/laravel-ignition": "^2.3",
+        "spatie/laravel-ray": "^1.33",
+        "tightenco/duster": "^2.4"
     },
     "config": {
         "optimize-autoloader": true,

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -36,7 +36,8 @@ return [
             'secret' => env('PUSHER_APP_SECRET'),
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
-                'host' => env('PUSHER_HOST') ?: 'api-' . env('PUSHER_APP_CLUSTER', 'mt1') . '.pusher.com',
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
                 'port' => env('PUSHER_PORT', 443),
                 'scheme' => env('PUSHER_SCHEME', 'https'),
                 'encrypted' => true,

--- a/config/cache.php
+++ b/config/cache.php
@@ -54,6 +54,7 @@ return [
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
+            'lock_path' => storage_path('framework/cache/data'),
         ],
 
         'memcached' => [

--- a/config/mail.php
+++ b/config/mail.php
@@ -36,6 +36,7 @@ return [
     'mailers' => [
         'smtp' => [
             'transport' => 'smtp',
+            'url' => env('MAIL_URL'),
             'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
             'port' => env('MAIL_PORT', 587),
             'encryption' => env('MAIL_ENCRYPTION', 'tls'),

--- a/config/queue.php
+++ b/config/queue.php
@@ -75,6 +75,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Job Batching
+    |--------------------------------------------------------------------------
+    |
+    | The following options configure the database and table that store job
+    | batching information. These options can be updated to any database
+    | connection and table which has been defined by your application.
+    |
+    */
+
+    'batching' => [
+        'database' => env('DB_CONNECTION', 'mysql'),
+        'table' => 'job_batches',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Failed Queue Jobs
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This pull request includes recent changes to Laravel skeleton files. Although some of these changes may be considered optional, they may be required to use recent additions - such as the [`hashed` attribute cast](https://github.com/laravel/framework/pull/46947) and [log processors](https://github.com/laravel/framework/pull/46344). This also includes new configuration options and skeleton slimming.

Since Laravel has moved to an annual release cycle, changes since the initial release may reach a critical mass. When they do, you will receive this automated pull request as part of your _Shifty Plan_.

**Before merging**, you need to:

- Checkout the `shift-mid-laravel-10` branch
- Review **all** pull request comments for additional changes
- Run `composer update` (if the scripts fail, add `--no-scripts`)
- Clear any config, route, or view cache
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

If you would like more detail you may [view the full changes](https://github.com/laravel/laravel/compare/v10.0.0...v10.2.6). You may also stay informed of weekly Laravel release highlights through the [Shifty Bits Newsletter](https://shiftybits.news/).
