### PR TITLE
Onboarding Sail (docker)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
+# If you want to use Sail, set this to true
+# APP_SAIL_MODE=true
 APP_URL=https://ozzie.test
 APP_TWITTER="tightenco"
 

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
-# If you want to use Sail, set this to true
-# APP_SAIL_MODE=true
+APP_SERVICE="ozzie.test"
 APP_URL=https://ozzie.test
 APP_TWITTER="tightenco"
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 npm-debug.log
 yarn-error.log
 .env
+auth.json
 /.phpunit.cache
 /.phpunit.result.cache
 .php_cs.cache

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'
 1. Clone the repo (`git clone git@github.com:tighten/ozzie.git && cd ozzie`)
 2. Install dependencies
 
-    `composer install`
     ```shell
     docker run --rm \
         -u "$(id -u):$(id -g)" \
@@ -49,7 +48,6 @@ alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'
         composer install --ignore-platform-reqs
     ```
 
-    `npm install`
     ```shell
     sail npm install
     ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 ## Local Installation
 
+### MacOS - Valet
 1. Clone the repo (`git clone git@github.com:tighten/ozzie.git && cd ozzie`)
 2. Install dependencies (`composer install && npm install`)
 3. Run `valet secure` to use `https` for the local domain
@@ -18,12 +19,51 @@
     - Application Name: `Local Ozzie`
     - Homepage URL: `https://ozzie.test`
     - Application Description: `Local Version of Ozzie`
-    - Authorization Callback URL: `http://ozzie.test/auth/callback`
+    - Authorization Callback URL: `https://ozzie.test/auth/callback`
 4. Copy the example `.env` file: `cp .env.example .env` and modify its settings to match your local install, including the client ID and secret from the previous step
 5. Run `php artisan key:generate`
 6. Create a database (by default `.env` looks for one named `ozzie`) and run the migrations (`php artisan migrate`)
 7. Fetch the projects list (into the database) by using the `projects:fetch` command. Alternatively, you can seed your `projects` table using a `projects.json` file at the root of the project (see below for more info).
 9. Fetch all projects' stats for the first time using `stats:fetch`
+
+### Sail - Docker
+
+*ensure you have docker installed and running*
+
+For the following steps, you'll need to have the `sail` command available. You can alias it by running:
+```shell
+alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'
+```
+[For more info around aliasing check this part of the docs](https://laravel.com/docs/10.x/sail#configuring-a-shell-alias)
+
+1. Clone the repo (`git clone git@github.com:tighten/ozzie.git && cd ozzie`)
+2. Install dependencies
+
+    `composer install`
+    ```shell
+    docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v "$(pwd):/var/www/html" \
+        -w /var/www/html \
+        laravelsail/php82-composer:latest \
+        composer install --ignore-platform-reqs
+    ```
+
+    `npm install`
+    ```shell
+    sail npm install
+    ```
+
+3. Create a [GitHub OAuth Application](https://github.com/settings/developers). If you use Valet to serve your application locally, you can use the following settings:
+    - Application Name: `Local Ozzie`
+    - Homepage URL: `http://localhost`
+    - Application Description: `Local Version of Ozzie`
+    - Authorization Callback URL: `http://localhost/auth/callback`
+4. Copy the example `.env` file: `cp .env.example .env` and modify its settings to match your local install, including the client ID and secret from the previous step
+5. Run `sail artisan key:generate`
+6. Run the migrations (`sail artisan migrate`)
+7. Fetch the projects list (into the database) by using the `projects:fetch` command. Alternatively, you can seed your `projects` table using a `projects.json` file at the root of the project (see below for more info).
+8. Fetch all projects' stats for the first time using `stats:fetch`
 
 > Note: If you're not using a tool like Laravel Valet, run `php artisan serve` and visit your site at http://127.0.0.1:8000; you'll also want to modify your GitHub app settings to use http://127.0.0.1:8000 instead of http://ozzie.test
 

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.13",
+        "laravel/sail": "^1.29",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
         "pestphp/pest": "^2.33",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1dfb8d31d19ebe85dd33c5b920c30a45",
+    "content-hash": "8afa22ffbd24d27e194f850504ee33a7",
     "packages": [
         {
             "name": "brick/math",
@@ -9065,6 +9065,69 @@
             "time": "2024-03-08T09:58:59+00:00"
         },
         {
+            "name": "laravel/sail",
+            "version": "v1.29.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sail.git",
+                "reference": "a8e4e749735ba2f091856eafeb3f99db8cd6b621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/a8e4e749735ba2f091856eafeb3f99db8cd6b621",
+                "reference": "a8e4e749735ba2f091856eafeb3f99db8cd6b621",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^9.52.16|^10.0|^11.0",
+                "illuminate/contracts": "^9.52.16|^10.0|^11.0",
+                "illuminate/support": "^9.52.16|^10.0|^11.0",
+                "php": "^8.0",
+                "symfony/console": "^6.0|^7.0",
+                "symfony/yaml": "^6.0|^7.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^7.0|^8.0|^9.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "bin": [
+                "bin/sail"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sail\\SailServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Docker files for running a basic Laravel application.",
+            "keywords": [
+                "docker",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sail/issues",
+                "source": "https://github.com/laravel/sail"
+            },
+            "time": "2024-05-16T21:39:11+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.11",
             "source": {
@@ -12134,6 +12197,77 @@
                 }
             ],
             "time": "2024-01-23T15:02:46+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "fa34c77015aa6720469db7003567b9f772492bf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/fa34c77015aa6720469db7003567b9f772492bf2",
+                "reference": "fa34c77015aa6720469db7003567b9f772492bf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+    ozzie.test:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.2
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.2/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+            IGNITION_LOCAL_SITES_PATH: '${PWD}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - mysql
+    mysql:
+        image: 'mysql/mysql-server:8.0'
+        ports:
+            - '${FORWARD_DB_PORT:-3306}:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: '%'
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 1
+        volumes:
+            - 'sail-mysql:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - mysqladmin
+                - ping
+                - '-p${DB_PASSWORD}'
+            retries: 3
+            timeout: 5s
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sail-mysql:
+        driver: local

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
             laravel({
                 input: ['resources/ts/app.ts'],
                 refresh: true,
-                valetTls: !envConfig?.parsed?.APP_SAIL_MODE ?? envAppUrl.hostname,
+                valetTls: !envConfig?.parsed?.LARAVEL_SAIL ?? envAppUrl.hostname,
             }),
             vue({
                 template: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
             laravel({
                 input: ['resources/ts/app.ts'],
                 refresh: true,
-                valetTls: envAppUrl.hostname,
+                valetTls: !envConfig?.parsed?.APP_SAIL_MODE ?? envAppUrl.hostname,
             }),
             vue({
                 template: {


### PR DESCRIPTION
## Highlights
- Onboards sails deps and out of the box `docker-compose.yml`
- Tweaks the vite config to play nice in none valet environments
- Updates readme and gitignore 

## Doubts 
- Any particular reason https was strict? given sails lets the hostname up in the air, if we want to approach it from our end we could explore adding caddy to the mix
- Given sail out of the box has strong opinions around the `.env` database config, wasn't 100% if it was worth highlighting on the `.env.example` or in the actual readme under the sail instructions

### References
- #91
- #92 