### PR TITLE
Test the `stats:fetch` command, and report if Packagist download count fails

### DIFF
--- a/app/Console/Commands/FetchProjectStats.php
+++ b/app/Console/Commands/FetchProjectStats.php
@@ -54,6 +54,7 @@ class FetchProjectStats extends Command
 
         // Fetch download counts (if applicable)
         $packagist = Package::fromProject($project);
+
         if ($packagist->requestOk) {
             $project->downloads_total = $packagist->totalDownloads;
             $project->downloads_last_30_days = $packagist->monthlyDownloads;

--- a/app/Console/Commands/FetchProjectStats.php
+++ b/app/Console/Commands/FetchProjectStats.php
@@ -54,8 +54,10 @@ class FetchProjectStats extends Command
 
         // Fetch download counts (if applicable)
         $packagist = Package::fromProject($project);
-        $project->downloads_total = $packagist->totalDownloads;
-        $project->downloads_last_30_days = $packagist->monthlyDownloads;
+        if ($packagist->requestOk) {
+            $project->downloads_total = $packagist->totalDownloads;
+            $project->downloads_last_30_days = $packagist->monthlyDownloads;
+        }
 
         $project->is_hidden = $githubProject->isArchived() || $project->is_hidden;
 

--- a/app/Remotes/Packagist/Package.php
+++ b/app/Remotes/Packagist/Package.php
@@ -14,6 +14,8 @@ class Package
 
     public $totalDownloads = 0;
 
+    public $requestOk = false;
+
     protected $url;
 
     public function __construct($namespace, $name)
@@ -32,7 +34,13 @@ class Package
     {
         $response = Http::get($this->url);
 
+        report_if(
+            $response->serverError(),
+            "HTTP Error: Was unable to fetch from packagist {$this->url}"
+        );
+
         if ($response->ok()) {
+            $this->requestOk = true;
             $this->downloadsData = Arr::get($response->json(), 'package.downloads', 0);
             $this->monthlyDownloads = $this->downloadsData['monthly'];
             $this->totalDownloads = $this->downloadsData['total'];

--- a/tests/Feature/FetchProjectStatsTest.php
+++ b/tests/Feature/FetchProjectStatsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\Cache\CachedProjectList;
 use App\Models\Maintainer;
 use App\Models\Project;
 use Github\Api\Issue;

--- a/tests/Feature/FetchProjectStatsTest.php
+++ b/tests/Feature/FetchProjectStatsTest.php
@@ -35,34 +35,32 @@ class FetchProjectStatsTest extends TestCase
             ]),
         ]);
 
-        $issueMock = Mockery::mock(Issue::class);
-        $issueMock->shouldReceive('all')
+        $issuesMock = Mockery::mock(Issue::class);
+        $issuesMock->shouldReceive('all')
             ->with('tighten', 'bar')
             ->once()
             ->andReturn([]);
+        GitHubClient::shouldReceive('issues')
+            ->once()
+            ->andReturn($issuesMock);
 
-        $moc = Mockery::mock(PullRequest::class);
-        $moc->shouldReceive('all')
+        $pullRequestsMock = Mockery::mock(PullRequest::class);
+        $pullRequestsMock->shouldReceive('all')
             ->with('tighten', 'bar')
             ->once()
             ->andReturn([]);
+        GitHubClient::shouldReceive('pullRequests')
+            ->once()
+            ->andReturn($pullRequestsMock);
 
-        $repoMock = Mockery::mock(Repo::class);
-        $repoMock->shouldReceive('show')
+        $reposMock = Mockery::mock(Repo::class);
+        $reposMock->shouldReceive('show')
             ->with('tighten', 'bar')
             ->once()
             ->andReturn(['archived' => false]);
-
-        GitHubClient::shouldReceive('issues')
-            ->once()
-            ->andReturn($issueMock);
-        GitHubClient::shouldReceive('pullRequests')
-            ->once()
-            ->andReturn($moc);
-
         GitHubClient::shouldReceive('repo')
             ->once()
-            ->andReturn($repoMock);
+            ->andReturn($reposMock);
 
         $project = Project::factory()->create([
             'namespace' => 'tighten',

--- a/tests/Feature/FetchProjectStatsTest.php
+++ b/tests/Feature/FetchProjectStatsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Cache\CachedProjectList;
+use App\Models\Maintainer;
+use App\Models\Project;
+use Github\Api\Issue;
+use Github\Api\PullRequest;
+use Github\Api\Repo;
+use GrahamCampbell\GitHub\Facades\GitHub as GitHubClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Mockery;
+use Tests\TestCase;
+
+class FetchProjectStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function fetch_stats_and_persist_successfully(): void
+    {
+        Http::preventStrayRequests();
+
+        Http::fake([
+            'packagist.org/packages/tighten/bar.json' => Http::response([
+                'package' => [
+                    'downloads' => [
+                        'total' => 1000,
+                        'monthly' => 100,
+                    ],
+                ],
+            ]),
+        ]);
+
+        $issueMock = Mockery::mock(Issue::class);
+        $issueMock->shouldReceive('all')
+            ->with('tighten', 'bar')
+            ->once()
+            ->andReturn([]);
+
+        $moc = Mockery::mock(PullRequest::class);
+        $moc->shouldReceive('all')
+            ->with('tighten', 'bar')
+            ->once()
+            ->andReturn([]);
+
+        $repoMock = Mockery::mock(Repo::class);
+        $repoMock->shouldReceive('show')
+            ->with('tighten', 'bar')
+            ->once()
+            ->andReturn(['archived' => false]);
+
+        GitHubClient::shouldReceive('issues')
+            ->once()
+            ->andReturn($issueMock);
+        GitHubClient::shouldReceive('pullRequests')
+            ->once()
+            ->andReturn($moc);
+
+        GitHubClient::shouldReceive('repo')
+            ->once()
+            ->andReturn($repoMock);
+
+        $project = Project::factory()->create([
+            'namespace' => 'tighten',
+            'name' => 'bar',
+            'packagist_name' => null,
+        ]);
+        $maintainer = Maintainer::factory()->create([
+            'github_username' => 'Baz',
+        ]);
+        $project->maintainers()->attach($maintainer);
+
+        $this->artisan('stats:fetch')->assertSuccessful();
+        $project->refresh();
+
+        $this->assertEquals($project->downloads_total, 1000);
+        $this->assertEquals($project->downloads_last_30_days, 100);
+        $this->assertEquals($project->issues_count, 0);
+        $this->assertEquals($project->pull_requests_count, 0);
+        $this->assertEquals($project->issues, collect([]));
+        $this->assertEquals($project->pull_requests, collect([]));
+        $this->assertNotEmpty(Cache::get('projects'));
+    }
+
+    /** @test */
+    public function report_errors_if_fetching_fails(): void
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/Feature/FetchProjectStatsTest.php
+++ b/tests/Feature/FetchProjectStatsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\Models\Maintainer;
 use App\Models\Project;
 use Github\Api\Issue;
 use Github\Api\PullRequest;
@@ -41,10 +40,6 @@ class FetchProjectStatsTest extends TestCase
             'name' => 'existing_package',
             'packagist_name' => null,
         ]);
-        $maintainer = Maintainer::factory()->create([
-            'github_username' => 'Baz',
-        ]);
-        $project->maintainers()->attach($maintainer);
 
         $this->artisan('stats:fetch')->assertSuccessful();
         $project->refresh();
@@ -62,7 +57,7 @@ class FetchProjectStatsTest extends TestCase
     }
 
     /** @test */
-    public function fetch_stats_does_not_overwrite_packagist_stats(): void
+    public function failed_stats_fetch_does_not_overwrite_packagist_stats(): void
     {
         Http::preventStrayRequests();
 
@@ -79,10 +74,6 @@ class FetchProjectStatsTest extends TestCase
             'downloads_total' => 100,
             'downloads_last_30_days' => 10,
         ]);
-        $maintainer = Maintainer::factory()->create([
-            'github_username' => 'Baz',
-        ]);
-        $project->maintainers()->attach($maintainer);
 
         $this->artisan('stats:fetch')->assertSuccessful();
 


### PR DESCRIPTION
## Highlights
- Tests `stats:fetch` command 
- Mocks HTTP and GitHub requests
- Reports if 500 on Packagist

## Notes
- We try to fetch on all packages, regardless if they exist or not in packagist.org, which feel odd
- If packagist.org, for whatever reason, fails to report, we would no longer overwrite download counts

reference 
- #89 
- #88  