### PR TITLE
Adds test coverage for commands and project api routes

### DIFF
--- a/app/Cache/CachedProjectList.php
+++ b/app/Cache/CachedProjectList.php
@@ -28,10 +28,6 @@ class CachedProjectList
                     ->transform(fn ($project) => app(CachedProjectResource::class)($project->packagist_name))
                     ->sortByDesc(fn ($project) => $project['debt_score'])
                     ->values();
-
-                return Project::all()
-                    ->sortByDesc(fn ($project) => $project['debt_score'])
-                    ->values();
             }
         );
     }

--- a/app/Console/Commands/FetchProjectStats.php
+++ b/app/Console/Commands/FetchProjectStats.php
@@ -49,8 +49,9 @@ class FetchProjectStats extends Command
         $project->issues_count = $issues->count();
         $project->pull_requests_count = $pullRequests->count();
 
-        $project->issues = $issues;
-        $project->pull_requests = $pullRequests;
+        // We call ->values() here to re-key the collection after filtering
+        $project->issues = $issues->values();
+        $project->pull_requests = $pullRequests->values();
 
         // Fetch download counts (if applicable)
         $packagist = Package::fromProject($project);

--- a/app/Http/Resources/ProjectResource.php
+++ b/app/Http/Resources/ProjectResource.php
@@ -7,9 +7,10 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class ProjectResource extends JsonResource
 {
+    public static $wrap = null;
+
     public function toArray($request): array
     {
-        self::withoutWrapping();
         $sparkline = new Sparkline;
         $sparkline->setLineColorRGB(67, 79, 181);
         $sparkline->deactivateBackgroundColor();

--- a/app/OrgSlack.php
+++ b/app/OrgSlack.php
@@ -12,4 +12,9 @@ class OrgSlack
     {
         return config('services.slack.webhook_url');
     }
+
+    public function getKey()
+    {
+        return 'org-slack-key';
+    }
 }

--- a/tests/Feature/CreateProjectSnapshotsTest.php
+++ b/tests/Feature/CreateProjectSnapshotsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Cache\CachedProjectList;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class CreateProjectSnapshotsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function one_snapshot_is_created_for_each_project(): void
+    {
+        $projects = Project::factory()
+            ->count(3)
+            ->withPrs([['number' => 1], ['number' => 2], ['number' => 3]])
+            ->withIssues([['number' => 1], ['number' => 2]])
+            ->create();
+
+        $this->artisan('stats:snapshot')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseCount('snapshots', 3);
+
+        $projects->each(function ($project) {
+            $this->assertDatabaseHas('snapshots', [
+                'project_id' => $project->id,
+                'snapshot_date' => now()->format('Y-m-d'),
+                'debt_score' => $project->debtScore(),
+                'pull_request_count' => 3,
+                'old_pull_request_count' => 0,
+                'issue_count' => 2,
+                'old_issue_count' => 0,
+                'downloads_total' => 0,
+                'downloads_last_30_days' => 0,
+            ]);
+        });
+    }
+
+    /** @test */
+    public function no_snapshots_are_created_if_the_project_has_already_been_snapshotted_today(): void
+    {
+        Project::factory()
+            ->create();
+
+        $this->artisan('stats:snapshot')
+            ->assertExitCode(0);
+
+        $this->artisan('stats:snapshot')
+            ->expectsOutput('No projects need snapshots for ' . now()->format('Y-m-d'))
+            ->assertExitCode(0);
+
+        $this->assertDatabaseCount('snapshots', 1);
+    }
+
+    /** @test */
+    public function the_force_option_overwrites_the_project_snapshot_taken_today(): void
+    {
+        $project = Project::factory()
+            ->create(['downloads_total' => 50]);
+
+        $this->artisan('stats:snapshot')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseCount('snapshots', 1);
+        $this->assertDatabaseHas('snapshots', [
+            'project_id' => $project->id,
+            'downloads_total' => 50,
+        ]);
+
+        $project->update(['downloads_total' => 1000]);
+
+        $this->artisan('stats:snapshot --force')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseCount('snapshots', 1);
+        $this->assertDatabaseHas('snapshots', [
+            'project_id' => $project->id,
+            'downloads_total' => 1000,
+        ]);
+    }
+
+    /** @test */
+    public function no_snapshots_are_created_if_no_projects_exist(): void
+    {
+        $this->artisan('stats:snapshot')
+            ->expectsOutput('No projects need snapshots for ' . now()->format('Y-m-d'))
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function the_cache_is_cleared_and_rebuilt_after_snapshots_are_taken(): void
+    {
+        Cache::shouldReceive('clear')
+            ->once();
+
+        $cacheRebuilt = false;
+
+        $this->app->bind(CachedProjectList::class, function () use (&$cacheRebuilt) {
+            return function () use (&$cacheRebuilt) {
+                $cacheRebuilt = true;
+            };
+        });
+
+        Project::factory()->create();
+
+        $this->artisan('stats:snapshot')
+            ->assertExitCode(0);
+
+        $this->assertTrue($cacheRebuilt);
+    }
+}

--- a/tests/Feature/FetchGitHubProjectsTest.php
+++ b/tests/Feature/FetchGitHubProjectsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use Github\Api\Organization;
+use Github\Api\PullRequest;
+use Github\Api\Repo;
+use GrahamCampbell\GitHub\Facades\GitHub as GitHubClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Mockery;
+use Tests\TestCase;
+
+class FetchGitHubProjectsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::preventStrayRequests();
+
+        Http::fake([
+            'packagist.org/search.json?q=tighten&per_page=100' => Http::response([
+                'results' => [
+                    [
+                        "name" => "tighten/ziggy",
+                        "description" => "Use your Laravel named routes in JavaScript.",
+                        "url" => "https://packagist.org/packages/tighten/ziggy",
+                        "repository" => "https://github.com/tighten/ziggy",
+                        "downloads" => 16043634,
+                        "favers" => 3697
+                    ],
+                    [
+                        "name" => "tighten/collect",
+                        "description" => "Collect - Illuminate Collections as a separate package.",
+                        "url" => "https://packagist.org/packages/tighten/collect",
+                        "repository" => "https://github.com/tighten/collect",
+                        "downloads" => 17251907,
+                        "favers" => 1540,
+                        "abandoned" => "illuminate/collections"
+                    ]
+                ],
+            ]),
+        ]);
+
+        $this->mockGithubClient('tighten');
+    }
+
+    /** @test */
+    public function fetch_projects_and_persist_successfully(): void
+    {
+        $this->artisan('projects:fetch');
+
+        $this->assertDatabaseCount('projects', 2);
+
+        $this->assertDatabaseHas('projects', [
+            'namespace' => 'tighten',
+            'name' => 'ziggy',
+            'packagist_name' => 'tighten/ziggy',
+        ]);
+
+        $this->assertDatabaseHas('projects', [
+            'namespace' => 'tighten',
+            'name' => 'collect',
+            'packagist_name' => 'tighten/collect',
+        ]);
+    }
+
+    /** @test */
+    public function fetch_projects_and_persist_successfully_with_all_option_enabled()
+    {
+        $this->artisan('projects:fetch --all');
+
+        $this->assertDatabaseCount('projects', 4);
+    }
+
+    /** @test */
+    public function fetch_projects_and_persist_successfully_with_archived_option_enabled()
+    {
+        $this->artisan('projects:fetch --archived');
+
+        $this->assertDatabaseCount('projects', 3);
+    }
+
+    /** @test */
+    public function fetch_projects_and_persist_successfully_with_fork_option_enabled()
+    {
+        $this->artisan('projects:fetch --fork');
+
+        $this->assertDatabaseCount('projects', 3);
+    }
+
+    /** @test */
+    public function avoid_persisting_projects_that_already_exist_in_the_database(): void
+    {
+        $existingProject = Project::factory()->create([
+            'namespace' => 'tighten',
+            'name' => 'ziggy',
+            'packagist_name' => 'tighten/ziggy',
+        ]);
+
+        $this->artisan('projects:fetch');
+
+        $this->assertDatabaseCount('projects', 2);
+        $this->assertEquals($existingProject->updated_at, $existingProject->fresh()->updated_at);
+    }
+
+    public function mockGithubClient($namespace): void
+    {
+        $repoMock = Mockery::mock(Repo::class);
+
+        $repoMock->shouldReceive('org')
+            ->with($namespace, [
+                'page' => 1,
+                'per_page' => 100,
+            ])
+            ->once()
+            ->andReturn([
+                [
+                    'full_name' => 'tighten/ziggy',
+                    'description' => 'Use your Laravel named routes in JavaScript.',
+                    'url' => 'https://api.github.com/repos/tighten/ziggy',
+                    'archived' => false,
+                    'fork' => false,
+                ],
+                [
+                    'full_name' => 'tighten/collect',
+                    'description' => 'Collect - Illuminate Collections as a separate package.',
+                    'url' => 'https://api.github.com/repos/tighten/collect',
+                    'archived' => false,
+                    'fork' => false,
+                ],
+                [
+                    'full_name' => 'tighten/FlexSlider',
+                    'description' => 'An awesome, fully responsive jQuery slider plugin',
+                    'url' => 'https://api.github.com/repos/tighten/FlexSlider',
+                    'archived' => false,
+                    'fork' => true,
+                ],
+                [
+                    'full_name' => 'tighten/confomo',
+                    'description' => 'ConFOMO is a simple tool that makes it easy to track your friends at conferences.',
+                    'url'  => 'https://api.github.com/repos/tighten/confomo',
+                    'archived' => true,
+                    'fork' => false,
+                ]
+            ]);
+
+        $repoMock->shouldReceive('org')
+            ->with($namespace, [
+                'page' => 2,
+                'per_page' => 100,
+            ])
+            ->once()
+            ->andReturn([]);
+
+        GitHubClient::shouldReceive('repositories')
+            ->andReturn($repoMock);
+    }
+}

--- a/tests/Feature/FetchGitHubProjectsTest.php
+++ b/tests/Feature/FetchGitHubProjectsTest.php
@@ -3,12 +3,9 @@
 namespace Tests\Feature;
 
 use App\Models\Project;
-use Github\Api\Organization;
-use Github\Api\PullRequest;
 use Github\Api\Repo;
 use GrahamCampbell\GitHub\Facades\GitHub as GitHubClient;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Mockery;
 use Tests\TestCase;
@@ -27,22 +24,22 @@ class FetchGitHubProjectsTest extends TestCase
             'packagist.org/search.json?q=tighten&per_page=100' => Http::response([
                 'results' => [
                     [
-                        "name" => "tighten/ziggy",
-                        "description" => "Use your Laravel named routes in JavaScript.",
-                        "url" => "https://packagist.org/packages/tighten/ziggy",
-                        "repository" => "https://github.com/tighten/ziggy",
-                        "downloads" => 16043634,
-                        "favers" => 3697
+                        'name' => 'tighten/ziggy',
+                        'description' => 'Use your Laravel named routes in JavaScript.',
+                        'url' => 'https://packagist.org/packages/tighten/ziggy',
+                        'repository' => 'https://github.com/tighten/ziggy',
+                        'downloads' => 16043634,
+                        'favers' => 3697,
                     ],
                     [
-                        "name" => "tighten/collect",
-                        "description" => "Collect - Illuminate Collections as a separate package.",
-                        "url" => "https://packagist.org/packages/tighten/collect",
-                        "repository" => "https://github.com/tighten/collect",
-                        "downloads" => 17251907,
-                        "favers" => 1540,
-                        "abandoned" => "illuminate/collections"
-                    ]
+                        'name' => 'tighten/collect',
+                        'description' => 'Collect - Illuminate Collections as a separate package.',
+                        'url' => 'https://packagist.org/packages/tighten/collect',
+                        'repository' => 'https://github.com/tighten/collect',
+                        'downloads' => 17251907,
+                        'favers' => 1540,
+                        'abandoned' => 'illuminate/collections',
+                    ],
                 ],
             ]),
         ]);
@@ -144,10 +141,10 @@ class FetchGitHubProjectsTest extends TestCase
                 [
                     'full_name' => 'tighten/confomo',
                     'description' => 'ConFOMO is a simple tool that makes it easy to track your friends at conferences.',
-                    'url'  => 'https://api.github.com/repos/tighten/confomo',
+                    'url' => 'https://api.github.com/repos/tighten/confomo',
                     'archived' => true,
                     'fork' => false,
-                ]
+                ],
             ]);
 
         $repoMock->shouldReceive('org')

--- a/tests/Feature/FetchProjectStatsTest.php
+++ b/tests/Feature/FetchProjectStatsTest.php
@@ -50,16 +50,16 @@ class FetchProjectStatsTest extends TestCase
         $this->assertEquals($project->issues_count, 1);
         $this->assertEquals($project->pull_requests_count, 1);
         $this->assertEquals($project->issues, collect([
-                [
-                    'labels' => [['name' => 'help wanted']],
-                    'created_at' => '2021-01-01T00:00:00.000000Z',
-                    'html_url' => 'https://example.com/issue/2',
-                    'pull_request' => null,
-                    'title' => 'Readme is unclear',
-                    'number' => '1234',
-                    'body' => 'Something in the readme is unclear and needs to be updated.',
-                    'user' => 'appleseed',
-                ]
+            [
+                'labels' => [['name' => 'help wanted']],
+                'created_at' => '2021-01-01T00:00:00.000000Z',
+                'html_url' => 'https://example.com/issue/2',
+                'pull_request' => null,
+                'title' => 'Readme is unclear',
+                'number' => '1234',
+                'body' => 'Something in the readme is unclear and needs to be updated.',
+                'user' => 'appleseed',
+            ],
         ]));
         $this->assertEquals($project->pull_requests, collect([
             [
@@ -72,7 +72,7 @@ class FetchProjectStatsTest extends TestCase
                 'title' => 'Add Readme',
                 'labels' => [],
                 'user' => 'johncash',
-            ]
+            ],
         ]));
 
         $this->assertEquals($project->is_hidden, false);
@@ -117,7 +117,7 @@ class FetchProjectStatsTest extends TestCase
                 'number' => '1234',
                 'body' => 'Something in the readme is unclear and needs to be updated.',
                 'user' => 'appleseed',
-            ]
+            ],
         ]));
         $this->assertEquals($project->pull_requests, collect([
             [
@@ -130,7 +130,7 @@ class FetchProjectStatsTest extends TestCase
                 'title' => 'Add Readme',
                 'labels' => [],
                 'user' => 'johncash',
-            ]
+            ],
         ]));
 
         $this->assertEquals($project->is_hidden, false);
@@ -183,12 +183,12 @@ class FetchProjectStatsTest extends TestCase
                 // Include a draft PR to test that it's filtered out
                 [
                     'draft' => true,
-                    'created_at' => '2021-01-01T00:00:00.000000Z'
+                    'created_at' => '2021-01-01T00:00:00.000000Z',
                 ],
                 // Include a PR that's in progress to test that it's filtered out
                 [
                     'labels' => [['name' => 'in progress']],
-                    'created_at' => '2021-01-01T00:00:00.000000Z'
+                    'created_at' => '2021-01-01T00:00:00.000000Z',
                 ],
                 // Include an open PR to test that it's included
                 [
@@ -201,7 +201,7 @@ class FetchProjectStatsTest extends TestCase
                     'title' => 'Add Readme',
                     'labels' => [],
                     'user' => 'johncash',
-                ]
+                ],
             ]);
         GitHubClient::shouldReceive('pullRequests')
             ->once()

--- a/tests/Feature/FetchProjectStatsTest.php
+++ b/tests/Feature/FetchProjectStatsTest.php
@@ -47,10 +47,33 @@ class FetchProjectStatsTest extends TestCase
         $this->assertEquals($project->downloads_total, 1000);
         $this->assertEquals($project->downloads_last_30_days, 100);
 
-        $this->assertEquals($project->issues_count, 0);
-        $this->assertEquals($project->pull_requests_count, 0);
-        $this->assertEquals($project->issues, collect([]));
-        $this->assertEquals($project->pull_requests, collect([]));
+        $this->assertEquals($project->issues_count, 1);
+        $this->assertEquals($project->pull_requests_count, 1);
+        $this->assertEquals($project->issues, collect([
+                [
+                    'labels' => [['name' => 'help wanted']],
+                    'created_at' => '2021-01-01T00:00:00.000000Z',
+                    'html_url' => 'https://example.com/issue/2',
+                    'pull_request' => null,
+                    'title' => 'Readme is unclear',
+                    'number' => '1234',
+                    'body' => 'Something in the readme is unclear and needs to be updated.',
+                    'user' => 'appleseed',
+                ]
+        ]));
+        $this->assertEquals($project->pull_requests, collect([
+            [
+                'body' => 'This PR adds a readme to the project',
+                'created_at' => '2021-01-01T00:00:00.000000Z',
+                'draft' => false,
+                'html_url' => 'https://example.com/pr/1',
+                'node_id' => 12345,
+                'number' => 1,
+                'title' => 'Add Readme',
+                'labels' => [],
+                'user' => 'johncash',
+            ]
+        ]));
 
         $this->assertEquals($project->is_hidden, false);
         $this->assertNotEmpty(Cache::get('projects'));
@@ -82,10 +105,33 @@ class FetchProjectStatsTest extends TestCase
         $this->assertEquals($project->downloads_total, 100);
         $this->assertEquals($project->downloads_last_30_days, 10);
 
-        $this->assertEquals($project->issues_count, 0);
-        $this->assertEquals($project->pull_requests_count, 0);
-        $this->assertEquals($project->issues, collect([]));
-        $this->assertEquals($project->pull_requests, collect([]));
+        $this->assertEquals($project->issues_count, 1);
+        $this->assertEquals($project->pull_requests_count, 1);
+        $this->assertEquals($project->issues, collect([
+            [
+                'labels' => [['name' => 'help wanted']],
+                'created_at' => '2021-01-01T00:00:00.000000Z',
+                'html_url' => 'https://example.com/issue/2',
+                'pull_request' => null,
+                'title' => 'Readme is unclear',
+                'number' => '1234',
+                'body' => 'Something in the readme is unclear and needs to be updated.',
+                'user' => 'appleseed',
+            ]
+        ]));
+        $this->assertEquals($project->pull_requests, collect([
+            [
+                'body' => 'This PR adds a readme to the project',
+                'created_at' => '2021-01-01T00:00:00.000000Z',
+                'draft' => false,
+                'html_url' => 'https://example.com/pr/1',
+                'node_id' => 12345,
+                'number' => 1,
+                'title' => 'Add Readme',
+                'labels' => [],
+                'user' => 'johncash',
+            ]
+        ]));
 
         $this->assertEquals($project->is_hidden, false);
         $this->assertNotEmpty(Cache::get('projects'));
@@ -97,7 +143,34 @@ class FetchProjectStatsTest extends TestCase
         $issuesMock->shouldReceive('all')
             ->with($namespace, $repo)
             ->once()
-            ->andReturn([]);
+            ->andReturn([
+                // Include an issue that's in progress to test that it's filtered out
+                [
+                    'labels' => [['name' => 'in progress']],
+                    'created_at' => '2021-01-01T00:00:00.000000Z',
+                ],
+                // Include an issue that has a PR associated with it to test that it's filtered out
+                [
+                    'labels' => [['name' => 'good first issue']],
+                    'created_at' => '2021-01-01T00:00:00.000000Z',
+                    'html_url' => 'https://example.com/issue/1',
+                    'pull_request' => 'https://example.com/pr/1',
+                    'title' => 'Need to add a readme',
+                    'number' => '1234',
+                    'body' => 'This repo does not have a readme',
+                    'user' => 'johnsmith',
+                ],
+                [
+                    'labels' => [['name' => 'help wanted']],
+                    'created_at' => '2021-01-01T00:00:00.000000Z',
+                    'html_url' => 'https://example.com/issue/2',
+                    'pull_request' => null,
+                    'title' => 'Readme is unclear',
+                    'number' => '1234',
+                    'body' => 'Something in the readme is unclear and needs to be updated.',
+                    'user' => 'appleseed',
+                ],
+            ]);
         GitHubClient::shouldReceive('issues')
             ->once()
             ->andReturn($issuesMock);
@@ -106,7 +179,30 @@ class FetchProjectStatsTest extends TestCase
         $pullRequestsMock->shouldReceive('all')
             ->with($namespace, $repo)
             ->once()
-            ->andReturn([]);
+            ->andReturn([
+                // Include a draft PR to test that it's filtered out
+                [
+                    'draft' => true,
+                    'created_at' => '2021-01-01T00:00:00.000000Z'
+                ],
+                // Include a PR that's in progress to test that it's filtered out
+                [
+                    'labels' => [['name' => 'in progress']],
+                    'created_at' => '2021-01-01T00:00:00.000000Z'
+                ],
+                // Include an open PR to test that it's included
+                [
+                    'body' => 'This PR adds a readme to the project',
+                    'created_at' => '2021-01-01T00:00:00.000000Z',
+                    'draft' => false,
+                    'html_url' => 'https://example.com/pr/1',
+                    'node_id' => 12345,
+                    'number' => 1,
+                    'title' => 'Add Readme',
+                    'labels' => [],
+                    'user' => 'johncash',
+                ]
+            ]);
         GitHubClient::shouldReceive('pullRequests')
             ->once()
             ->andReturn($pullRequestsMock);

--- a/tests/Feature/GetProjectsTest.php
+++ b/tests/Feature/GetProjectsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GetProjectsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function get_a_list_of_all_projects(): void
+    {
+        $project_a = Project::factory()->create(['namespace' => 'acme', 'name' => 'project_a']);
+        $project_b = Project::factory()->create(['namespace' => 'acme', 'name' => 'project_b']);
+
+        $this->getJson('/api/projects')
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    [
+                        'namespace' => 'acme',
+                        'name' => 'project_a',
+                        'issues' => [],
+                        'pull_requests' => [],
+                        'downloads_total' => 0,
+                        'downloads_last_30_days' => 0,
+                        'packagist_name' => $project_a->packagist_name,
+                        'is_hidden' => false,
+                        'debt_score' => 0,
+                    ],
+                    [
+                        'namespace' => 'acme',
+                        'name' => 'project_b',
+                        'issues' => [],
+                        'pull_requests' => [],
+                        'downloads_total' => 0,
+                        'downloads_last_30_days' => 0,
+                        'packagist_name' => $project_b->packagist_name,
+                        'is_hidden' => false,
+                        'debt_score' => 0,
+                    ],
+                ]
+            ]);
+    }
+}

--- a/tests/Feature/GetProjectsTest.php
+++ b/tests/Feature/GetProjectsTest.php
@@ -42,7 +42,7 @@ class GetProjectsTest extends TestCase
                         'is_hidden' => false,
                         'debt_score' => 0,
                     ],
-                ]
+                ],
             ]);
     }
 }

--- a/tests/Feature/OutputStatsTest.php
+++ b/tests/Feature/OutputStatsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OutputStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function outputs_stats_in_the_console(): void
+    {
+        Project::factory()->create(['name' => 'project_a', 'namespace' => 'acme', 'issues_count' => 600]);
+        Project::factory()->create(['name' => 'project_b', 'namespace' => 'acme', 'issues_count' => 300]);
+        Project::factory()->create(['name' => 'project_c', 'namespace' => 'acme', 'issues_count' => 100]);
+
+        $this->artisan('stats:output')
+            ->expectsTable(
+                ['Project', 'Debt Score'],
+                [
+                    ['acme/project_a', '6'],
+                    ['acme/project_b', '3'],
+                    ['acme/project_c', '1'],
+                ])
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/SendStatsToSlackTest.php
+++ b/tests/Feature/SendStatsToSlackTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use App\Notifications\SendOzzieStats;
+use App\OrgSlack;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+use function Symfony\Component\String\s;
+
+class SendStatsToSlackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function sends_latest_stats_to_slack(): void
+    {
+        Notification::fake();
+
+        Project::factory()->create([
+            'namespace' => 'acme',
+            'name' => 'project-a',
+            'issues_count' => 500
+        ]);
+
+        Project::factory()->create([
+            'namespace' => 'acme',
+            'name' => 'project-b',
+            'issues_count' => 700
+        ]);
+
+        $this->artisan('stats:slack')
+            ->assertExitCode(0);
+
+        Notification::assertSentTo(new OrgSlack(), SendOzzieStats::class, function ($notification, $channels, $notifiable) {
+            $slackNotification = $notification->toSlack($notifiable);
+
+            return $channels === ['slack']
+                && $notifiable instanceof OrgSlack
+                && $slackNotification->username === 'Ozzie'
+                && $slackNotification->icon === ':robot_face:'
+                && $slackNotification->content === sprintf('Here are your Ozzie stats! %s', config('app.url'))
+                && $slackNotification->attachments[0]->blocks[0]->text['text'] === '*<https://github.com/acme/project-b|Acme / Project-b>*: *7*'
+                && $slackNotification->attachments[1]->blocks[0]->text['text'] === '*<https://github.com/acme/project-a|Acme / Project-a>*: *5*'
+                && $slackNotification->attachments[0]->blocks[1]->elements[1]['text'] === "PRs: 0 (*0 old*)\t\t\tIssues: 700 (*0 old*)"
+                && $slackNotification->attachments[1]->blocks[1]->elements[1]['text'] === "PRs: 0 (*0 old*)\t\t\tIssues: 500 (*0 old*)";
+        });
+    }
+}

--- a/tests/Feature/SendStatsToSlackTest.php
+++ b/tests/Feature/SendStatsToSlackTest.php
@@ -8,7 +8,6 @@ use App\OrgSlack;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
-use function Symfony\Component\String\s;
 
 class SendStatsToSlackTest extends TestCase
 {
@@ -22,19 +21,19 @@ class SendStatsToSlackTest extends TestCase
         Project::factory()->create([
             'namespace' => 'acme',
             'name' => 'project-a',
-            'issues_count' => 500
+            'issues_count' => 500,
         ]);
 
         Project::factory()->create([
             'namespace' => 'acme',
             'name' => 'project-b',
-            'issues_count' => 700
+            'issues_count' => 700,
         ]);
 
         $this->artisan('stats:slack')
             ->assertExitCode(0);
 
-        Notification::assertSentTo(new OrgSlack(), SendOzzieStats::class, function ($notification, $channels, $notifiable) {
+        Notification::assertSentTo(new OrgSlack, SendOzzieStats::class, function ($notification, $channels, $notifiable) {
             $slackNotification = $notification->toSlack($notifiable);
 
             return $channels === ['slack']

--- a/tests/Feature/ShowProjectTest.php
+++ b/tests/Feature/ShowProjectTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowProjectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function show_the_details_of_a_single_project(): void
+    {
+        $project = Project::factory()->create([
+            'namespace' => $namespace = 'acme',
+            'name' => $name = 'my-project',
+            'packagist_name'  => null,
+        ]);
+
+        $this->getJson("/api/projects/$namespace/$name")
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    'namespace' => 'acme',
+                    'name' => 'my-project',
+                    'issues' => [],
+                    'pull_requests' => [],
+                    'downloads_total' => 0,
+                    'downloads_last_30_days' => 0,
+                    'packagist_name' => $project->packagist_name,
+                    'is_hidden' => false,
+                    'debt_score' => 0,
+                ]
+            ]);
+    }
+}

--- a/tests/Feature/ShowProjectTest.php
+++ b/tests/Feature/ShowProjectTest.php
@@ -16,10 +16,10 @@ class ShowProjectTest extends TestCase
         $project = Project::factory()->create([
             'namespace' => $namespace = 'acme',
             'name' => $name = 'my-project',
-            'packagist_name'  => null,
+            'packagist_name' => null,
         ]);
 
-        $this->getJson("/api/projects/$namespace/$name")
+        $this->getJson("/api/projects/{$namespace}/{$name}")
             ->assertOk()
             ->assertJson([
                 'data' => [
@@ -32,7 +32,7 @@ class ShowProjectTest extends TestCase
                     'packagist_name' => $project->packagist_name,
                     'is_hidden' => false,
                     'debt_score' => 0,
-                ]
+                ],
             ]);
     }
 }


### PR DESCRIPTION
Adds the following test cases:

Commands:

- `CreateProjectSnapshotsTest`
- `FetchGitHubProjectsTest`
- `FetchProjectStatsTest`
- `OutputStatsTest`
- `SendStatsToSlackTest`

API routes:

- `GetProjectsTest`
- `ShowProjectTest`

Also makes some minor changes:

- Removes an unreachable return statement in `CachedProjectList`.
- Re-keys the issues and pull requests collections in `FetchProjectStats` to make it easier to assert their values when testing.
- Changes how we avoid wrapping in the `ProjectResource` because the previous approach actually removes wrapping from `JsonResource` affecting all json resources.
- Implements the `getKey()` method on the `OrgSlack` notifiable to allow testing using `Notification::fake()`.

---

All test cases passing with these changes and linter is green. Happy to make any changes that you see fit in order to get this merged.